### PR TITLE
Add new asyncio tutorials in the HOWTO section

### DIFF
--- a/Doc/howto/asyncio-advanced.rst
+++ b/Doc/howto/asyncio-advanced.rst
@@ -1,0 +1,42 @@
+.. _asyncio-advanced-tutorial:
+
+******************************
+  Advanced asyncio Tutorial
+******************************
+
+:Author: List TBD
+
+
+.. topic:: Abstract
+
+   This tutorial explains how network sockets and selectors are tied to
+   the asyncio event loop, how to use the asyncio streams API to implement
+   a client for a network application protocol, and finally how to use
+   the asyncio transport and protocol APIs to write better structured and
+   faster client libraries.
+
+   The Redis protocol is used for examples, and a simple Redis protocol
+   server is provided so that the tutorial can be completed without an
+   actual Redis installation.
+
+
+A Short Primer on Network IO
+============================
+
+
+Case Study: The Redis Protocol
+==============================
+
+
+A Redis Client Library Using the Streams API
+============================================
+
+
+A Redis Client Library Using Transports and Protocols
+=====================================================
+
+
+Appendix: A Simple Restricted Redis Protocol Server
+=================================================== 
+
+

--- a/Doc/howto/asyncio.rst
+++ b/Doc/howto/asyncio.rst
@@ -1,0 +1,44 @@
+.. _asyncio-tutorial:
+
+******************************
+  Asynchronous IO Tutorial 
+******************************
+
+:Author: List TBD
+
+
+.. topic:: Abstract
+
+   This tutorial explains python coroutines (async/await) and the motivation
+   for using them to provide structure for applications using asynchronous IO.
+   The asyncio event loop from the python standard library is used for
+   scheduling coroutines and providing low-level IO operations.
+
+   This tutorial should provide you with the background necessary to begin
+   writing applications that make use of python coroutines.
+
+
+Why Asynchronous IO?
+====================
+
+
+Coroutines in Python
+====================
+
+
+Simple Coroutine Examples using asyncio
+=======================================
+
+
+Coroutine Examples using aiohttp
+================================
+
+
+How asyncio Works
+=================
+
+
+Tasks in asyncio
+================
+
+

--- a/Doc/howto/index.rst
+++ b/Doc/howto/index.rst
@@ -29,4 +29,6 @@ Currently, the HOWTOs are:
    ipaddress.rst
    clinic.rst
    instrumentation.rst
+   asyncio.rst
+   asyncio-advanced.rst
 


### PR DESCRIPTION
Add outlines for the new asyncio tutorials
proposed in bpo-30145. One tutorial is a simple
introduction to coroutines in python, and the other
shows how to use streams and transports to write
asyncio clients.

See issue #1 